### PR TITLE
use `snippetIdToString` to expand correctly when using typescript-defined snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ nvim-cmp source for [denippet.vim](https://github.com/uga-rosa/denippet.vim)
 require("cmp")({
   snippet = {
     expand = function(args)
-      vim.fn["denippet#anonymous"](args.body)
+      if args.body ~= "" then
+          vim.fn["denippet#anonymous"](args.body)
+      end
     end,
   },
   sources = {

--- a/lua/cmp_denippet.lua
+++ b/lua/cmp_denippet.lua
@@ -53,13 +53,6 @@ function source:resolve(completion_item, callback)
   callback(completion_item)
 end
 
-function source:execute(completion_item,callback)
-  local snippet = completion_item.data.snippet
-  local body = snippet.body
-  vim.fn["denippet#anonymous"](body)
-	callback(completion_item)
-end
-
 function source:_get_text_edit(params, prefix, body)
   local chars = vim.fn.split(vim.fn.escape(prefix, [[\/?]]), [[\zs]])
   local chars_pattern = [[\%(\V]] .. table.concat(chars, [[\m\|\V]]) .. [[\m\)]]

--- a/lua/cmp_denippet.lua
+++ b/lua/cmp_denippet.lua
@@ -36,7 +36,8 @@ end
 
 function source:resolve(completion_item, callback)
   local snippet = completion_item.data.snippet
-  local body = vim.fn["denippet#to_string"](snippet.body) --[[@as string]]
+  local body = vim.fn["denippet#to_string_by_id"](snippet.id) --[[@as string]]
+  completion_item.data.snippet.body = body
   local documentation = vim.split(body:gsub("\r\n?", "\n"), "\n")
   if #documentation > 0 then
     table.insert(documentation, 1, "```" .. completion_item.data.filetype)
@@ -50,6 +51,13 @@ function source:resolve(completion_item, callback)
     value = table.concat(documentation, "\n"),
   }
   callback(completion_item)
+end
+
+function source:execute(completion_item,callback)
+  local snippet = completion_item.data.snippet
+  local body = snippet.body
+  vim.fn["denippet#anonymous"](body)
+	callback(completion_item)
 end
 
 function source:_get_text_edit(params, prefix, body)


### PR DESCRIPTION
Related to https://github.com/uga-rosa/denippet.vim/pull/22
fixes: #1 

using `vim.fn["denippet#to_string_by_id"]` to get correct body when using typescript-defined snippet.
