### PR TITLE
fix: use default nvim-cmp keyword pattern

### DIFF
--- a/lua/cmp_denippet.lua
+++ b/lua/cmp_denippet.lua
@@ -6,10 +6,6 @@ function source.new()
   return setmetatable({}, { __index = source })
 end
 
-function source:get_keyword_pattern()
-  return "."
-end
-
 ---Invoke completion (required).
 ---@param params cmp.SourceCompletionApiParams
 ---@param callback fun(response: lsp.CompletionResponse|nil)


### PR DESCRIPTION
fixes: #3
